### PR TITLE
Fix includes and some file names

### DIFF
--- a/Baked Rendering/BVH.h
+++ b/Baked Rendering/BVH.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <Core/Core.h>
 #include <vector>
-#include <Mesh/Mesh.h>
+#include "Core/Core.h"
+#include "Mesh/Mesh.h"
 
 namespace LDEngine {
 	namespace Rendering {

--- a/Baked Rendering/MeshTextureWrapper.cpp
+++ b/Baked Rendering/MeshTextureWrapper.cpp
@@ -1,5 +1,5 @@
-#include "meshtexturewrapper.h"
 #include <iostream>
+#include "MeshTextureWrapper.h"
 
 LDEngine::Rendering::Mesh::WrappedModel::WrappedModel()
 {

--- a/Baked Rendering/MeshTextureWrapper.h
+++ b/Baked Rendering/MeshTextureWrapper.h
@@ -1,8 +1,8 @@
 #pragma once
+#include <GL/glew.h>
+#include <SFML/Graphics.hpp>
 #include "BVH.h"
-#include <GL\glew.h> 
-#include <SFML\Graphics.hpp> 
-#include <Mesh/Mesh.h>
+#include "Mesh/Mesh.h"
 
 #define MATERIAL_TEXTURE_QUALITY 256 //the texture maps' resolution (they all have to be the same) 
 #define MATERIAL_TEXTURE_QUALITY_SQUARED MATERIAL_TEXTURE_QUALITY * MATERIAL_TEXTURE_QUALITY

--- a/Baked Rendering/PathTraceBaker.h
+++ b/Baked Rendering/PathTraceBaker.h
@@ -1,9 +1,10 @@
 #pragma once
-#include <Real Time Rendering/ShadowPass.h>
+#include "Core Rendering/FrameBuffer.h"
+#include "Core Rendering/Shader.h"
 #include "MeshTextureWrapper.h"
-#include <Core Rendering/Shader.h>
-#include <Core Rendering/FrameBuffer.h>
-#include "wraptobaketexture.h"
+#include "Real Time Rendering/ShadowPass.h"
+#include "WrapToBakeTexture.h"
+
 void SavePixelDataToImageFromFloatVector(const char *fileName, std::vector<float> data, glm::ivec2 Resolution, bool YInverted = false,bool Alpha = false);
 
 

--- a/Baked Rendering/ReflectionProbeRenderer.cpp
+++ b/Baked Rendering/ReflectionProbeRenderer.cpp
@@ -1,8 +1,8 @@
-#include "reflectionproberenderer.h"
 #include <fstream>
+#include <iostream>
 #include <Windows.h>
 #include "PathTraceBaker.h"
-#include <iostream>
+#include "ReflectionProbeRenderer.h"
 
 void LDEngine::Rendering::ReflectionProbes::ReflectionProbeBaker::PrepareReflectionProbeBaking(unsigned int Resolution)
 {

--- a/Baked Rendering/ReflectionProbeRenderer.h
+++ b/Baked Rendering/ReflectionProbeRenderer.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <Mesh/Mesh.h>
-#include <Core Rendering/FrameBuffer.h>
-#include <Real Time Rendering/ShadowPass.h>
+#include "Core Rendering/FrameBuffer.h"
+#include "Mesh/Mesh.h"
+#include "Real Time Rendering/ShadowPass.h"
 
 const std::string OutPutNames[] = { "PosX.png", "NegX.png", "PosY.png", "NegY.png", "PosZ.png", "NegZ.png" };
 

--- a/Baked Rendering/WrapToBakeTexture.cpp
+++ b/Baked Rendering/WrapToBakeTexture.cpp
@@ -1,6 +1,6 @@
-#include "wraptobaketexture.h"
-#include <SFML/Graphics.hpp>
 #include <iostream>
+#include <SFML/Graphics.hpp>
+#include "WrapToBakeTexture.h"
 
 struct TriangleData {
 	glm::vec3 Position;

--- a/Baked Rendering/WrapToBakeTexture.h
+++ b/Baked Rendering/WrapToBakeTexture.h
@@ -1,6 +1,7 @@
-#include <Core/Core.h>
-#include <Mesh/Mesh.h>
 #include <vector>
+#include "Core/Core.h"
+#include "Mesh/Mesh.h"
+
 namespace LDEngine {
 	namespace Rendering {
 		namespace Mesh {

--- a/Collisions/Collision.h
+++ b/Collisions/Collision.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <Core/Core.h>
 #include <array>
+#include "Core/Core.h"
 
 namespace LDEngine {
 	namespace Collisions {

--- a/Core Rendering/FrameBuffer.cpp
+++ b/Core Rendering/FrameBuffer.cpp
@@ -1,4 +1,4 @@
-#include "framebuffer.h"
+#include "FrameBuffer.h"
 
 LDEngine::Rendering::Core::FrameBufferObject::FrameBufferObject(glm::ivec2 Resolution, bool SamplerShadow, bool alpha, bool generatemip) 
 	: GenerateMip(generatemip), FrameBuffer(0), ColorBuffer(0), DepthBuffer(0), Resolution(Resolution)

--- a/Core Rendering/FrameBuffer.h
+++ b/Core Rendering/FrameBuffer.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <GL/glew.h>
-#include <Mesh\Mesh.h> 
+#include "Mesh/Mesh.h"
 
 
 namespace LDEngine {

--- a/Core Rendering/Shader.h
+++ b/Core Rendering/Shader.h
@@ -1,4 +1,5 @@
 #pragma once
+
 namespace LDEngine {
 	namespace Rendering {
 		namespace Core {

--- a/Core Rendering/Texture.cpp
+++ b/Core Rendering/Texture.cpp
@@ -1,9 +1,9 @@
-#include "texture.h"
-#include <GL/glew.h>
-#include <Core Rendering/FrameBuffer.h>
-#include <SFML/Graphics.hpp>
 #include <iostream>
-#include <Baked Rendering/reflectionproberenderer.h>
+#include <GL/glew.h>
+#include <SFML/Graphics.hpp>
+#include "Baked Rendering/ReflectionProbeRenderer.h"
+#include "Core Rendering/FrameBuffer.h"
+#include "Texture.h"
 
 LDEngine::Rendering::Core::Texture2D::~Texture2D()
 {

--- a/Core Rendering/Texture.h
+++ b/Core Rendering/Texture.h
@@ -1,7 +1,6 @@
 #pragma once
-
-#include <Core Rendering/Shader.h>
-#include <Core/Core.h>
+#include "Core/Core.h"
+#include "Core Rendering/Shader.h"
 
 const Matrix4f CubeProjection = glm::perspective(glm::radians(90.0f), 1.0f, 0.01f, 10.0f);
 const Matrix4f CubeViews[] =

--- a/Core Rendering/Window.cpp
+++ b/Core Rendering/Window.cpp
@@ -1,5 +1,5 @@
-#include "window.h"
 #include <GL/glew.h>
+#include "Window.h"
 
 void Window::SetResolution(Vector2i Resolution)
 {

--- a/Core Rendering/Window.h
+++ b/Core Rendering/Window.h
@@ -1,10 +1,10 @@
 #pragma once
-
-#include <glm\common.hpp>
-#include <glm\glm.hpp>
-#include <glm\mat4x4.hpp>
+#include <glm/common.hpp>
+#include <glm/glm.hpp>
+#include <glm/mat4x4.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
+#include <SFML/Graphics.hpp>
 
 using Vector2f = glm::vec2;
 using Vector2i = glm::ivec2;
@@ -29,8 +29,6 @@ using Matrix3d = glm::dmat3;
 
 using Matrix4f = glm::mat4;
 using Matrix4d = glm::dmat4;
-
-#include <SFML/Graphics.hpp>
 
 class Window {
 	Vector2i Resolution; 
@@ -63,7 +61,7 @@ class Window {
 
 	sf::Window * GetRawWindow(); 
 
-	inline Window() : Resolution(0), Fullscreen(false), RawWindow(nullptr), Title("LDEngine²"), FrameCount(0) {}
+	inline Window() : Resolution(0), Fullscreen(false), RawWindow(nullptr), Title("LDEngine?"), FrameCount(0) {}
 	Window(Vector2i Resolution, bool Fullscreen); 
 	~Window(); 
 }; 

--- a/Core/Camera.h
+++ b/Core/Camera.h
@@ -1,7 +1,6 @@
 #pragma once
-
-#include <Core\Core.h> 
-#include <Core Rendering/Window.h>
+#include "Core/Core.h"
+#include "Core Rendering/Window.h"
 
 namespace LDEngine {
 	namespace Control {

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -1,8 +1,7 @@
 #pragma once
+#include <cmath>
+#include "Core Rendering/Window.h"
 
-
-#include <math.h> 
-#include <Core Rendering/Window.h>
 #define PI 3.14159265
 
 namespace LDEngine {

--- a/Game/Enemy.cpp
+++ b/Game/Enemy.cpp
@@ -1,7 +1,6 @@
-#include "Enemy.h"
 #include <iostream>
-#include <Core Rendering/Texture.h>
-
+#include "Core Rendering/Texture.h"
+#include "Enemy.h"
 
 void LDEngine::Game::Enemy::UpdateEnemy(EnemyPath & Path, Window & Window, Control::Camera & Camera, std::vector<Collisions::AABB>& CollisionBoxes, std::vector<ParticleRequest> & ParticleRequests)
 {

--- a/Game/Enemy.h
+++ b/Game/Enemy.h
@@ -1,10 +1,10 @@
 #pragma once
 #include <vector>
-#include <Core/Core.h>
-#include <Core/Camera.h>
-#include <Collisions/Collision.h>
-#include <Mesh/AnimatedMesh.h>
-#include <Real Time Rendering/ParticleSystem.h>
+#include "Collisions/Collision.h"
+#include "Core/Camera.h"
+#include "Core/Core.h"
+#include "Mesh/AnimatedMesh.h"
+#include "Real Time Rendering/ParticleSystem.h"
 #include "Sound.h"
 
 namespace LDEngine {

--- a/Game/Weapons.cpp
+++ b/Game/Weapons.cpp
@@ -1,7 +1,6 @@
-#include "Weapons.h"
-#include <Mesh/AnimatedMesh.h>
 #include <iostream>
-
+#include "Mesh/AnimatedMesh.h"
+#include "Weapons.h"
 
 LDEngine::Rendering::Mesh::AnimatedKeyFrameModel PistolModel; 
 

--- a/Mesh/Mesh.h
+++ b/Mesh/Mesh.h
@@ -1,16 +1,15 @@
 #pragma once
-
-#include <vector> 
-#include <unordered_map> 
-#include <assimp\cimport.h>
-#include <assimp\mesh.h>
-#include <assimp\Importer.hpp>
-#include <assimp\scene.h>
-#include <assimp\postprocess.h>
-#include <Core Rendering/Shader.h>
-#include <Core Rendering/Texture.h>
-#include <Core Rendering/Window.h>
-#include <Core\Camera.h> 
+#include <unordered_map>
+#include <vector>
+#include <assimp/cimport.h>
+#include <assimp/Importer.hpp>
+#include <assimp/mesh.h>
+#include <assimp/postprocess.h>
+#include <assimp/scene.h>
+#include "Core/Camera.h"
+#include "Core Rendering/Shader.h"
+#include "Core Rendering/Texture.h"
+#include "Core Rendering/Window.h"
 
 namespace LDEngine {
 	namespace Rendering {

--- a/Pipeline/Pipeline.h
+++ b/Pipeline/Pipeline.h
@@ -1,8 +1,7 @@
 #pragma once
+#include "Collisions/Collision.h"
+#include "Game/Sound.h"
 #include "RenderPipeLine.h"
-#include <Collisions/Collision.h>
-#include <Game/Sound.h>
-
 
 namespace LDEngine {
 	namespace Rendering {

--- a/Pipeline/RenderPipeLine.cpp
+++ b/Pipeline/RenderPipeLine.cpp
@@ -1,8 +1,8 @@
-#include "RenderPipeLine.h"
-#include <Windows.h>
-#include <iostream>
 #include <fstream>
-#include <Baked Rendering/reflectionproberenderer.h>
+#include <iostream>
+#include <Windows.h>
+#include "Baked Rendering/ReflectionProbeRenderer.h"
+#include "RenderPipeLine.h"
 
 void GetFilesInDirectory(std::vector<std::string> &out, const std::string &directory)
 {

--- a/Pipeline/RenderPipeLine.h
+++ b/Pipeline/RenderPipeLine.h
@@ -1,11 +1,11 @@
 #pragma once
-#include <Mesh/AnimatedMesh.h>
-#include <Core Rendering/FrameBuffer.h>
-#include <Real Time Rendering/ShadowPass.h>
-#include <Real Time Rendering/ParticleSystem.h>
-#include <Game/Wave.h>
-#include <Game/Weapons.h>
-#include <Core Rendering/UI.h>
+#include "Core Rendering/FrameBuffer.h"
+#include "Core Rendering/UI.h"
+#include "Game/Wave.h"
+#include "Game/Weapons.h"
+#include "Mesh/AnimatedMesh.h"
+#include "Real Time Rendering/ParticleSystem.h"
+#include "Real Time Rendering/ShadowPass.h"
 
 namespace LDEngine {
 	namespace Rendering {

--- a/Real Time Rendering/ParticleSystem.h
+++ b/Real Time Rendering/ParticleSystem.h
@@ -1,7 +1,8 @@
 #pragma once
-#include <Mesh\Mesh.h>
-#include <Core Rendering/Shader.h>
-#include <Core Rendering/FrameBuffer.h>
+#include "Core Rendering/FrameBuffer.h"
+#include "Core Rendering/Shader.h"
+#include "Mesh/Mesh.h"
+
 namespace LDEngine {
 	namespace Rendering {
 

--- a/Real Time Rendering/ShadowPass.cpp
+++ b/Real Time Rendering/ShadowPass.cpp
@@ -1,5 +1,6 @@
+#include "Core/Core.h"
 #include "ShadowPass.h"
-#include <Core\Core.h>
+
 namespace LDEngine {
 	namespace Rendering {
 		ShadowStructure::ShadowStructure()

--- a/Real Time Rendering/ShadowPass.h
+++ b/Real Time Rendering/ShadowPass.h
@@ -1,7 +1,8 @@
 #pragma once
-#include <Mesh\Mesh.h>
-#include <Core Rendering/Shader.h>
-#include <Core Rendering/FrameBuffer.h>
+#include "Core Rendering/FrameBuffer.h"
+#include "Core Rendering/Shader.h"
+#include "Mesh/Mesh.h"
+
 namespace LDEngine {
 	namespace Rendering {
 


### PR DESCRIPTION
* Some includes had wrongly capitalized header names.
* Some includes used wrong slash as path delimiter.
* Some includes were in angle brackets instead of quotes.
* Some file names were wrongly capitalized.
* Includes reordered in more sensible manner.
* Unifies empty lines in include area.
* Removes trailing whtespace in include area.